### PR TITLE
Address some part list upload issues

### DIFF
--- a/app/models/element.rb
+++ b/app/models/element.rb
@@ -124,7 +124,7 @@ class Element < ApplicationRecord
     return unless original_image_url
 
     extension = File.extname(original_image_url)
-    file = "#{guid}#{extension}"
+    file = "#{Rails.root}/tmp/#{guid}#{extension}"
     begin
       File.open(file, 'wb') do |fo|
         fo.write URI.parse(original_image_url).open.read

--- a/app/views/admin/parts_lists/show.html.erb
+++ b/app/views/admin/parts_lists/show.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </div>
 </div>
-<% if @parts_list.jid? %>
+<% if @parts_list.parts.blank? %>
   <div align="center">
     Working on Lot <%= @current_count.to_i + 1 %> of <%= @total_count %>
   </div>


### PR DESCRIPTION
This PR addresses 2 issues. 

1. There was a race condition where a job would be done and the jid deleted from the parts list right after the parts list had been loaded, but before the parts list show page had been rendered, leading to the page getting stuck checking the status. Fixed by looking for the parts hash to be populated instead of the jid being gone. The parts hash won't be populate unless the parts list has been parsed successfully.

2. Parts images were getting generated in the Rails root. This was changed to the /tmp dir.